### PR TITLE
Convert plugin class set into a list before indexing into it

### DIFF
--- a/tests/testsupport.py
+++ b/tests/testsupport.py
@@ -43,11 +43,13 @@ class CopyArtifactsTestCase(_common.TestCase):
        
         # Teardown
         if plugins._instances:
+            classes = list(plugins._classes)
+            
             # Unregister listners
-            del plugins._classes[0].listeners['import_task_files'][0]
+            del classes[0].listeners['import_task_files'][0]
         
             # Delete the plugin instance so a new one gets created for each test
-            del plugins._instances[plugins._classes[0]]
+            del plugins._instances[classes[0]]
 
     def _setup_library(self):
         self.lib_db = os.path.join(self.temp_dir, 'testlib.blb')


### PR DESCRIPTION
The beets plugin module was changed (https://github.com/sampsyo/beets/commit/e2718d792e814248fc336d13a6c5c33e4b579277) to store the plugin classes in a set rather than a list.  This pull request updates the supporting test code to accommodate this change.
