### PR TITLE
Using the logging mechanism provided by beets

### DIFF
--- a/beetsplug/copyartifacts.py
+++ b/beetsplug/copyartifacts.py
@@ -91,7 +91,7 @@ class CopyArtifactsPlugin(BeetsPlugin):
 
     def import_event(self, task, session):
         # TODO: import_event is called after all move_events
-        print 'import_event'
+        self._log.debug('import_event')
         imported_item = task.imported_items()[0]
         album_path = os.path.dirname(imported_item.path)
 
@@ -137,7 +137,7 @@ class CopyArtifactsPlugin(BeetsPlugin):
         self._dirs_seen.extend([source_path])
 
     def move_event(self, item, source, destination):
-        print 'move_event'
+        self._log.debug('move_event')
         source_path = os.path.dirname(source)
         dest_path = os.path.dirname(destination)
 
@@ -165,10 +165,10 @@ class CopyArtifactsPlugin(BeetsPlugin):
         self._dirs_seen.extend([source_path])
 
     def process_events(self):
-        print 'CLI exit'
+        self._log.debug('CLI exit')
         import json
-        print self._dirs_seen
-        print json.dumps(self._process_queue, indent=4, sort_keys=True)
+        self._log.debug('Dirs seen: {0}', self._dirs_seen)
+        self._log.debug(json.dumps(self._process_queue, indent=4, sort_keys=True))
 
         for item in self._process_queue:
             self.process_artifacts(item['files'], item['mapping'], False)
@@ -226,13 +226,13 @@ class CopyArtifactsPlugin(BeetsPlugin):
 
 
         if self.print_ignored and ignored_files:
-            print 'Ignored files:'
+            self._log.warning('Ignored files:')
             for f in ignored_files:
-                print '   ', os.path.basename(f)
+                self._log.warning('   {0}', os.path.basename(f))
 
     def _copy_artifact(self, source_file, dest_file):
         dest_file = beets.util.bytestring_path(dest_file)
-        print 'Copying artifact: {0}'.format(os.path.basename(dest_file))
+        self._log.info('Copying artifact: {0}'.format(os.path.basename(dest_file)))
         beets.util.copy(source_file, dest_file)
 
     def _move_artifact(self, source_file, dest_file):
@@ -241,6 +241,6 @@ class CopyArtifactsPlugin(BeetsPlugin):
             return
 
         dest_file = beets.util.bytestring_path(dest_file)
-        print 'Moving artifact: {0}'.format(os.path.basename(dest_file))
+        self._log.info('Moving artifact: {0}'.format(os.path.basename(dest_file)))
         beets.util.move(source_file, dest_file)
 


### PR DESCRIPTION
This PR changes the plugin so it uses the logging mechanism provided by beets. I've just replaced all `print` statements by calls to `self._log`. Those outputs which are definitively only for debugging are logged in "debug" level. The ones telling a file has been moved or copied are logged with "info" level. But I'm a bit unsure about the output of the ignored files since beets sets the logging level to "warning" while importing. To ensure the output of these ignored files, I used "warning" level here.
Any comments?