### PR TITLE
Use extend_path instead of namespace_packages

### DIFF
--- a/beetsplug/__init__.py
+++ b/beetsplug/__init__.py
@@ -1,1 +1,2 @@
-__import__('pkg_resources').declare_namespace(__name__)
+from pkgutil import extend_path
+__path__ = extend_path(__path__, __name__)

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,5 @@ setup(
     license='MIT',
 
     packages=['beetsplug'],
-    namespace_packages=['beetsplug'],
     install_requires = ['beets>=1.3.11']
 )


### PR DESCRIPTION
A fix for distributions that actually keep the files in separate
directories, e.g. NixOS.

Previously, all other built-in plugins would not be found.

Cf. https://github.com/geigerzaehler/beets-alternatives/blob/cb80b62b71451a799918014c537f4276e20e7d50/beetsplug/__init__.py