### PR TITLE
Python 3 compatibility

### DIFF
--- a/beetsplug/copyartifacts.py
+++ b/beetsplug/copyartifacts.py
@@ -74,7 +74,7 @@ class CopyArtifactsPlugin(BeetsPlugin):
         '''Replace path separators in value
             - ripped from beets/dbcore/db.py
         '''
-        sep_repl = beets.config['path_sep_replace'].get(unicode)
+        sep_repl = beets.config['path_sep_replace'].as_str()
         for sep in (os.path.sep, os.path.altsep):
             if sep:
                 value = value.replace(sep, sep_repl)


### PR DESCRIPTION
Copyartifacts is not compatible with Python 3, but beets gained mostly stable support recently. At least the Arch package has switched to Py3 already.

**EDIT**: Just saw #31.

The following crash occurs on import (and probably every command that moves files) with latest git versions of beets and copyartifacts:
```
Traceback (most recent call last):
  File "/usr/bin/beet", line 11, in <module>
    load_entry_point('beets==1.4.4', 'console_scripts', 'beet')()
  File "/usr/lib/python3.6/site-packages/beets/ui/__init__.py", line 1209, in main
    _raw_main(args)
  File "/usr/lib/python3.6/site-packages/beets/ui/__init__.py", line 1196, in _raw_main
    subcommand.func(lib, suboptions, subargs)
  File "/usr/lib/python3.6/site-packages/beets/ui/commands.py", line 930, in import_func
    import_files(lib, paths, query)
  File "/usr/lib/python3.6/site-packages/beets/ui/commands.py", line 907, in import_files
    session.run()
  File "/usr/lib/python3.6/site-packages/beets/importer.py", line 319, in run
    pl.run_parallel(QUEUE_SIZE)
  File "/usr/lib/python3.6/site-packages/beets/util/pipeline.py", line 445, in run_parallel
    six.reraise(exc_info[0], exc_info[1], exc_info[2])
  File "/usr/lib/python3.6/site-packages/six.py", line 686, in reraise
    raise value
  File "/usr/lib/python3.6/site-packages/beets/util/pipeline.py", line 358, in run
    self.coro.send(msg)
  File "/usr/lib/python3.6/site-packages/beets/util/pipeline.py", line 171, in coro
    task = func(*(args + (task,)))
  File "/usr/lib/python3.6/site-packages/beets/importer.py", line 1415, in manipulate_files
    session=session,
  File "/usr/lib/python3.6/site-packages/beets/importer.py", line 677, in manipulate_files
    item.move(copy, link)
  File "/usr/lib/python3.6/site-packages/beets/library.py", line 764, in move
    self.move_file(dest, copy, link)
  File "/usr/lib/python3.6/site-packages/beets/library.py", line 676, in move_file
    destination=dest)
  File "/usr/lib/python3.6/site-packages/beets/plugins.py", line 452, in send
    result = handler(**arguments)
  File "/usr/lib/python3.6/site-packages/beets/plugins.py", line 124, in wrapper
    return func(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/beetsplug/copyartifacts.py", line 120, in collect_artifacts
    'mapping': self._generate_mapping(item, dest_path)
  File "/usr/lib/python3.6/site-packages/beetsplug/copyartifacts.py", line 91, in _generate_mapping
    mapping[key] = self._format(mapping[key])
  File "/usr/lib/python3.6/site-packages/beetsplug/copyartifacts.py", line 77, in _format
    sep_repl = beets.config['path_sep_replace'].get(unicode)
NameError: name 'unicode' is not defined

```
This particular crash should be fixed in the PR: `confit`'s `as_str` is `unicode` on Python 2 and `str` on 3 IIRC. At least `path_sep_replace` is read like this in `beets/dbcore/db.py`.
There might be more problems on Python 3, but with this patch applied I could complete an import successfully.