### PR TITLE
Fix leftover top directory when no files are left

### DIFF
--- a/beetsplug/copyartifacts.py
+++ b/beetsplug/copyartifacts.py
@@ -32,7 +32,7 @@ class CopyArtifactsPlugin(BeetsPlugin):
 
         self.register_listener('item_moved', self.collect_artifacts)
         self.register_listener('item_copied', self.collect_artifacts)
-        self.register_listener('cli_exit', self.process_events)
+        self.register_listener('import_task_files', self.process_events)
 
     def _destination(self, filename, mapping):
         '''Returns a destination path a file should be moved to. The filename
@@ -193,7 +193,4 @@ class CopyArtifactsPlugin(BeetsPlugin):
 
         self._log.info('Moving artifact: {0}'.format(os.path.basename(dest_file)))
         beets.util.move(source_file, dest_file)
-
-        dir_path = os.path.split(source_file)[0]
-        beets.util.prune_dirs(dir_path, clutter=config['clutter'].as_str_seq())
 


### PR DESCRIPTION
Addresses the bug where a directory is left over even though beets
should clean it up. For example, take the following structure:

```
- ImportDir
  - Artist
    - Album
      - 01 song.mp3
      - 02 song.mp3
      - digital.pdf
```

where .pdf is specified as an artifact

After performing a move the current result is:

```
- ImportDir
  - Artist
```

This is due to the fact that the plugin is invoked after beets performs
its internal cleanup and that the plugin makes its own invokation to prune_dirs, but does so
without adding the top level directory.

To remedy this, the top level directory could be added to the prune_dirs
command, but perhaps more ideal is to have the plugin execute before the
finalize call in beets as in the following snippet:

```
def manipulate_files(session, task):
    """A coroutine (pipeline stage) that performs necessary file
    manipulations *after* items have been added to the library and
    finalizes each task.
    """
    if not task.skip:
        if task.should_remove_duplicates:
            task.remove_duplicates(session.lib)

        task.manipulate_files(
            move=session.config['move'],
            copy=session.config['copy'],
            write=session.config['write'],
            link=session.config['link'],
            session=session,
        )  #### <------ MOVE PLUGIN EXECUTION TO HERE

    # Progress, cleanup, and event.
    task.finalize(session) ### <---- PLUGIN EXECUTED AFTER

```

Signed-off-by: Andrew DeMaria <lostonamountain@gmail.com>