### PR TITLE
Add lib kwarg to process_events()

### DIFF
--- a/beetsplug/copyartifacts.py
+++ b/beetsplug/copyartifacts.py
@@ -122,7 +122,7 @@ class CopyArtifactsPlugin(BeetsPlugin):
         }])
         self._dirs_seen.extend([source_path])
 
-    def process_events(self):
+    def process_events(self, lib):
         for item in self._process_queue:
             self.process_artifacts(item['files'], item['mapping'], False)
 


### PR DESCRIPTION
Without this fix, the following exception is thrown:

    Traceback (most recent call last):
    File "/data/jan/Projects/beets/beets/plugins.py", line 140, in wrapper
        return func(*args, **kwargs)
    TypeError: process_events() got an unexpected keyword argument 'lib'

The lib kwarg has been introduced by this commit in beetbox/beets:

    commit 2ad5b4c665bd270243d7e31f77680e969d7cb315
    Author: Dang Mai <contact@dangmai.net>
    Date:   Thu Jan 31 16:33:53 2013 -0500

        Add lib parameter for cli_exit

This is a partial fix for issue #38.